### PR TITLE
custom configuration workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "structopt",
  "tar",
  "thiserror",
@@ -606,6 +607,12 @@ name = "libc"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "log"
@@ -1122,6 +1129,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1578,15 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ dialoguer = "0.4"
 dirs = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.8"
 semver = { version = "0.9.0", features = ["serde"] }
 indicatif = "0.14"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/commands/blockchain.rs
+++ b/src/commands/blockchain.rs
@@ -34,7 +34,12 @@ impl Command {
             Command::List => {
                 let config = cfg.load_jor().map_err(Error::JorfileLoadFailed)?;
                 for blockchain in config.blockchains().iter() {
-                    println!("\t{}\n{}\n", blockchain.name(), blockchain.description());
+                    println!(
+                        "\t{}\nGenesis block hash: {}\n{}\n",
+                        blockchain.name(),
+                        blockchain.block0_hash(),
+                        blockchain.description()
+                    );
                 }
             }
         }

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -1,0 +1,114 @@
+use crate::{common::JorupConfig, utils::blockchain::Blockchain};
+use structopt::StructOpt;
+use thiserror::Error;
+
+/// Output the default configuration for the given blockchain. This
+/// configuration can be customized and provided to `jorup run` later.
+#[derive(Debug, StructOpt)]
+pub struct Command {
+    /// The blockchain to get the configuration for
+    blockchain: String,
+
+    #[structopt(long, default_value = "yaml")]
+    format: ConfigFormat,
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Cannot run the node without valid blockchain")]
+    NoValidBlockchain(#[source] crate::utils::blockchain::Error),
+    #[error("Could not write JSON")]
+    Json(#[source] serde_json::Error),
+    #[error("Could not write YAML")]
+    Yaml(#[source] serde_yaml::Error),
+}
+
+#[derive(Debug)]
+enum ConfigFormat {
+    Json,
+    Yaml,
+}
+
+mod config {
+    use serde::Serialize;
+    use std::path::PathBuf;
+
+    #[derive(Serialize)]
+    pub struct Config {
+        pub log: Vec<Log>,
+        pub p2p: P2p,
+        pub rest: Rest,
+        pub storage: PathBuf,
+        pub secret_files: Vec<PathBuf>,
+    }
+
+    #[derive(Serialize)]
+    pub struct Log {
+        pub output: String,
+        pub level: String,
+        pub format: String,
+    }
+
+    #[derive(Serialize)]
+    pub struct P2p {
+        pub public_address: String,
+        pub trusted_peers: Vec<crate::config::TrustedPeer>,
+    }
+
+    #[derive(Serialize)]
+    pub struct Rest {
+        pub listen: String,
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Unknown configuration format value")]
+struct ConfigFormatError;
+
+impl Command {
+    pub fn run(&self, mut cfg: JorupConfig) -> Result<(), Error> {
+        let blockchain =
+            Blockchain::load(&mut cfg, &self.blockchain).map_err(Error::NoValidBlockchain)?;
+        blockchain.prepare().map_err(Error::NoValidBlockchain)?;
+
+        let output = config::Config {
+            log: vec![config::Log {
+                output: "stderr".to_string(),
+                level: "info".to_string(),
+                format: "plain".to_string(),
+            }],
+            p2p: config::P2p {
+                public_address: "/ip4/127.0.0.1/tcp/3000".to_string(),
+                trusted_peers: blockchain.entry().trusted_peers().to_vec(),
+            },
+            rest: config::Rest {
+                listen: "127.0.0.1:8080".to_string(),
+            },
+            storage: blockchain.get_node_storage(),
+            secret_files: vec![blockchain.get_node_secret()],
+        };
+
+        match self.format {
+            ConfigFormat::Json => {
+                serde_json::to_writer_pretty(std::io::stdout(), &output).map_err(Error::Json)
+            }
+            ConfigFormat::Yaml => {
+                serde_yaml::to_writer(std::io::stdout(), &output).map_err(Error::Yaml)
+            }
+        }
+    }
+}
+
+impl std::str::FromStr for ConfigFormat {
+    type Err = ConfigFormatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "json" {
+            Ok(Self::Json)
+        } else if s == "yaml" {
+            Ok(Self::Yaml)
+        } else {
+            Err(ConfigFormatError)
+        }
+    }
+}

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -1,4 +1,4 @@
-use crate::{common::JorupConfig, utils::blockchain::Blockchain};
+use crate::{common::JorupConfig, jormungandr_config as config, utils::blockchain::Blockchain};
 use structopt::StructOpt;
 use thiserror::Error;
 
@@ -27,38 +27,6 @@ pub enum Error {
 enum ConfigFormat {
     Json,
     Yaml,
-}
-
-mod config {
-    use serde::Serialize;
-    use std::path::PathBuf;
-
-    #[derive(Serialize)]
-    pub struct Config {
-        pub log: Vec<Log>,
-        pub p2p: P2p,
-        pub rest: Rest,
-        pub storage: PathBuf,
-        pub secret_files: Vec<PathBuf>,
-    }
-
-    #[derive(Serialize)]
-    pub struct Log {
-        pub output: String,
-        pub level: String,
-        pub format: String,
-    }
-
-    #[derive(Serialize)]
-    pub struct P2p {
-        pub public_address: String,
-        pub trusted_peers: Vec<crate::config::TrustedPeer>,
-    }
-
-    #[derive(Serialize)]
-    pub struct Rest {
-        pub listen: String,
-    }
 }
 
 #[derive(Debug, Error)]

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -35,6 +35,8 @@ struct ConfigFormatError;
 
 impl Command {
     pub fn run(&self, mut cfg: JorupConfig) -> Result<(), Error> {
+        use std::net::ToSocketAddrs;
+
         let blockchain =
             Blockchain::load(&mut cfg, &self.blockchain).map_err(Error::NoValidBlockchain)?;
         blockchain.prepare().map_err(Error::NoValidBlockchain)?;
@@ -50,7 +52,7 @@ impl Command {
                 trusted_peers: blockchain.entry().trusted_peers().to_vec(),
             },
             rest: config::Rest {
-                listen: "127.0.0.1:8080".to_string(),
+                listen: "127.0.0.1:8080".to_socket_addrs().unwrap().next().unwrap(),
             },
             storage: blockchain.get_node_storage(),
             secret_files: vec![blockchain.get_node_secret()],

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -47,14 +47,14 @@ impl Command {
                 level: "info".to_string(),
                 format: "plain".to_string(),
             }],
-            p2p: config::P2p {
-                public_address: "/ip4/127.0.0.1/tcp/3000".to_string(),
+            p2p: Some(config::P2p {
+                public_address: Some("/ip4/127.0.0.1/tcp/3000".to_string()),
                 trusted_peers: blockchain.entry().trusted_peers().to_vec(),
-            },
-            rest: config::Rest {
+            }),
+            rest: Some(config::Rest {
                 listen: "127.0.0.1:8080".to_socket_addrs().unwrap().next().unwrap(),
-            },
-            storage: blockchain.get_node_storage(),
+            }),
+            storage: Some(blockchain.get_node_storage()),
             secret_files: vec![blockchain.get_node_secret()],
         };
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod blockchain;
+mod defaults;
 mod info;
 mod node;
 mod run;
@@ -60,6 +61,7 @@ enum Command {
     Setup(setup::Command),
     Blockchain(blockchain::Command),
     Node(node::Command),
+    Defaults(defaults::Command),
 }
 
 #[derive(Debug, Error)]
@@ -80,6 +82,8 @@ pub enum Error {
     Setup(#[from] setup::Error),
     #[error(transparent)]
     Node(#[from] node::Error),
+    #[error(transparent)]
+    Defaults(#[from] defaults::Error),
 }
 
 impl RootCmd {
@@ -99,6 +103,7 @@ impl RootCmd {
             Command::Setup(cmd) => cmd.run(cfg)?,
             Command::Blockchain(cmd) => cmd.run(cfg)?,
             Command::Node(cmd) => cmd.run(cfg)?,
+            Command::Defaults(cmd) => cmd.run(cfg)?,
         }
 
         Ok(())

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -2,6 +2,7 @@ use crate::{
     common::JorupConfig,
     utils::{blockchain::Blockchain, release::Release, runner::RunnerControl, version::Version},
 };
+use std::path::PathBuf;
 use structopt::StructOpt;
 use thiserror::Error;
 
@@ -19,6 +20,15 @@ pub struct Command {
     /// Run the node as a daemon
     #[structopt(long)]
     daemon: bool,
+
+    /// Provide a custom configuration file to the node.
+    ///
+    /// Note that when using this flag `jorup` will not provide any
+    /// configuration to `jormungandr` besides what you specify in the
+    /// configuration file and extra arguments. The default configuration values
+    /// can be obtained with `jorup defaults`.
+    #[structopt(long)]
+    config: Option<PathBuf>,
 
     /// Extra parameters to pass on to the node
     ///
@@ -40,6 +50,8 @@ pub enum Error {
     CannotStartRunnerController(#[source] crate::utils::runner::Error),
     #[error("Unable to start node")]
     Start(#[source] crate::utils::runner::Error),
+    #[error("Cannot transform the configuration file path to its canonical form")]
+    Canonicalize(#[source] std::io::Error),
 }
 
 impl Command {
@@ -64,10 +76,24 @@ impl Command {
         let mut runner = RunnerControl::new(&blockchain, &release)
             .map_err(Error::CannotStartRunnerController)?;
 
+        let default_config = self.config.is_none();
+        let extra = {
+            let mut extra = self.extra;
+            if let Some(config_path) = self.config {
+                let config_path =
+                    std::fs::canonicalize(config_path).map_err(Error::Canonicalize)?;
+                extra.extend_from_slice(&[
+                    "--config".to_string(),
+                    config_path.display().to_string(),
+                ]);
+            }
+            extra
+        };
+
         if self.daemon {
-            runner.spawn(self.extra).map_err(Error::Start)
+            runner.spawn(default_config, extra).map_err(Error::Start)
         } else {
-            runner.run(self.extra).map_err(Error::Start)
+            runner.run(default_config, extra).map_err(Error::Start)
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::utils::version::VersionReq;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
 pub struct Config(Vec<Blockchain>);
@@ -13,7 +13,7 @@ pub struct Blockchain {
     trusted_peers: Vec<TrustedPeer>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrustedPeer {
     address: String,
     id: String,

--- a/src/jormungandr_config.rs
+++ b/src/jormungandr_config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{path::PathBuf, net::SocketAddr};
 
 #[derive(Deserialize, Serialize)]
 pub struct Config {
@@ -25,5 +25,5 @@ pub struct P2p {
 
 #[derive(Deserialize, Serialize)]
 pub struct Rest {
-    pub listen: String,
+    pub listen: SocketAddr,
 }

--- a/src/jormungandr_config.rs
+++ b/src/jormungandr_config.rs
@@ -8,10 +8,12 @@ use thiserror::Error;
 
 #[derive(Deserialize, Serialize)]
 pub struct Config {
+    #[serde(default)]
     pub log: Vec<Log>,
-    pub p2p: P2p,
-    pub rest: Rest,
-    pub storage: PathBuf,
+    pub p2p: Option<P2p>,
+    pub rest: Option<Rest>,
+    pub storage: Option<PathBuf>,
+    #[serde(default)]
     pub secret_files: Vec<PathBuf>,
 }
 
@@ -24,7 +26,8 @@ pub struct Log {
 
 #[derive(Deserialize, Serialize)]
 pub struct P2p {
-    pub public_address: String,
+    pub public_address: Option<String>,
+    #[serde(default)]
     pub trusted_peers: Vec<crate::config::TrustedPeer>,
 }
 

--- a/src/jormungandr_config.rs
+++ b/src/jormungandr_config.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Deserialize, Serialize)]
+pub struct Config {
+    pub log: Vec<Log>,
+    pub p2p: P2p,
+    pub rest: Rest,
+    pub storage: PathBuf,
+    pub secret_files: Vec<PathBuf>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct Log {
+    pub output: String,
+    pub level: String,
+    pub format: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct P2p {
+    pub public_address: String,
+    pub trusted_peers: Vec<crate::config::TrustedPeer>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct Rest {
+    pub listen: String,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod common;
 mod config;
+mod jormungandr_config;
 mod utils;
 
 use structopt::StructOpt;

--- a/src/utils/blockchain.rs
+++ b/src/utils/blockchain.rs
@@ -78,10 +78,6 @@ impl Blockchain {
         self.dir().join("node-storage")
     }
 
-    pub fn get_node_config(&self) -> PathBuf {
-        self.dir().join("node-config.yaml")
-    }
-
     pub fn get_node_secret(&self) -> PathBuf {
         self.dir().join("node-secret.yaml")
     }


### PR DESCRIPTION
A user can pass own custom configuration to `jormungandr`. To make that, they
only need to add the `--config` parameter with the path to the `jormumngandr`
configuration file in `jorup run`, for example:

    jorup run itn --config ./config.yaml

Note that this is the preferred way for providing custom configs. Writing

    jorup run itn -- --config ./config.yaml

will fail since `jormungandr` working directory is somewhere under `~/.jorup`.
When providing the parameter to `jorup` instead of `jormungandr`, `jorup` takes
care of expanding the path and providing it to `jormungandr`.

Another thing to note is that providing `--config` will prevent `jorup` from
providing any additional command line arguments to `jormungandr`. With this in
mind, you will need to provide all of the configuration values including the
list of trusted peers, storage, secrets, etc. These can be retrieved with

    jorup defaults itn

On top of that, since the configuration file format does not allow providing the
genesis block hash, you will need to provide it in the command line arguments.
You can get the genesis block hash from `jorup blockchains list` under your
blockchain name. Then you will need to run something like that:

    jorup run itn --config ./config.yaml -- --genesis-block-hash 8e4d2a343f3dcf9330ad9035b3e8d168e6728904262f2c434a4f8f934ec7b676
