### PR TITLE
Allow custom binaries

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::JorupConfig,
-    utils::{blockchain::Blockchain, release::Release, runner::RunnerControl},
+    utils::{blockchain::Blockchain, runner::RunnerControl},
 };
 use structopt::StructOpt;
 use thiserror::Error;
@@ -16,10 +16,6 @@ pub struct Command {
 pub enum Error {
     #[error("Cannot run the node without valid blockchain")]
     NoValidBlockchain(#[source] crate::utils::blockchain::Error),
-    #[error("Cannot run without compatible release")]
-    NoCompatibleRelease(#[source] crate::utils::release::Error),
-    #[error("No binaries for this blockchain")]
-    NoCompatibleBinaries,
     #[error("Unable to start the runner controller")]
     CannotStartRunnerController(#[source] crate::utils::runner::Error),
     #[error("Cannot collect node's info")]
@@ -32,16 +28,8 @@ impl Command {
             Blockchain::load(&mut cfg, &self.blockchain).map_err(Error::NoValidBlockchain)?;
         blockchain.prepare().map_err(Error::NoValidBlockchain)?;
 
-        let release = Release::load(&mut cfg, blockchain.jormungandr_version_req())
-            .map_err(Error::NoCompatibleRelease)?;
-
-        if release.asset_need_fetched() {
-            // asset release is not available
-            return Err(Error::NoCompatibleBinaries);
-        }
-
-        let mut runner = RunnerControl::new(&blockchain, &release)
-            .map_err(Error::CannotStartRunnerController)?;
+        let mut runner =
+            RunnerControl::load(&blockchain).map_err(Error::CannotStartRunnerController)?;
 
         runner.settings().map_err(Error::CannotCollectInfo)?;
         runner.info().map_err(Error::CannotCollectInfo)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -79,6 +79,7 @@ impl Command {
         blockchain.prepare().map_err(Error::NoValidBlockchain)?;
 
         let bin = if let Some(dir) = self.bin {
+            eprintln!("WARN: using custom binaries from {}", dir.display());
             dir
         } else {
             let release = if let Some(version) = self.version {

--- a/src/commands/shutdown.rs
+++ b/src/commands/shutdown.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::JorupConfig,
-    utils::{blockchain::Blockchain, release::Release, runner::RunnerControl},
+    utils::{blockchain::Blockchain, runner::RunnerControl},
 };
 use structopt::StructOpt;
 use thiserror::Error;
@@ -16,10 +16,6 @@ pub struct Command {
 pub enum Error {
     #[error("Cannot run the node without valid blockchain")]
     NoValidBlockchain(#[source] crate::utils::blockchain::Error),
-    #[error("Cannot run without compatible release")]
-    NoCompatibleRelease(#[source] crate::utils::release::Error),
-    #[error("No binaries for this blockchain")]
-    NoCompatibleBinaries,
     #[error("Unable to start the runner controller")]
     CannotStartRunnerController(#[source] crate::utils::runner::Error),
     #[error("unable to stop/shutdown the node")]
@@ -33,16 +29,8 @@ impl Command {
             Blockchain::load(&mut cfg, &self.blockchain).map_err(Error::NoValidBlockchain)?;
         blockchain.prepare().map_err(Error::NoValidBlockchain)?;
 
-        let release = Release::load(&mut cfg, blockchain.jormungandr_version_req())
-            .map_err(Error::NoCompatibleRelease)?;
-
-        if release.asset_need_fetched() {
-            // asset release is not available
-            return Err(Error::NoCompatibleBinaries);
-        }
-
-        let mut runner = RunnerControl::new(&blockchain, &release)
-            .map_err(Error::CannotStartRunnerController)?;
+        let mut runner =
+            RunnerControl::load(&blockchain).map_err(Error::CannotStartRunnerController)?;
 
         runner.shutdown().map_err(Error::ShutdownError)
     }

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -49,6 +49,7 @@ impl Command {
         blockchain.prepare().map_err(Error::NoValidBlockchain)?;
 
         let bin = if let Some(dir) = self.bin {
+            eprintln!("WARN: using custom binaries from {}", dir.display());
             dir.join("jcli")
         } else {
             let release = if let Some(version) = self.version {

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::JorupConfig,
-    utils::{blockchain::Blockchain, release::Release, runner::RunnerControl},
+    utils::{blockchain::Blockchain, release::Release, jcli::Jcli},
 };
 use structopt::StructOpt;
 use thiserror::Error;
@@ -24,12 +24,10 @@ pub enum Error {
     NoCompatibleRelease(#[source] crate::utils::release::Error),
     #[error("No binaries for this blockchain")]
     NoCompatibleBinaries,
-    #[error("Unable to start the runner controller")]
-    CannotStartRunnerController(#[source] crate::utils::runner::Error),
     #[error("Cannot create new wallet")]
-    CannotCreateWallet(#[source] crate::utils::runner::Error),
+    CannotCreateWallet(#[source] crate::utils::jcli::Error),
     #[error("Cannot get the wallet's address")]
-    CannotGetAddress(#[source] crate::utils::runner::Error),
+    CannotGetAddress(#[source] crate::utils::jcli::Error),
 }
 
 impl Command {
@@ -47,8 +45,7 @@ impl Command {
             return Err(Error::NoCompatibleBinaries);
         }
 
-        let mut runner = RunnerControl::new(&blockchain, &release)
-            .map_err(Error::CannotStartRunnerController)?;
+        let mut runner = Jcli::new(&blockchain, release.get_jcli());
 
         runner
             .get_wallet_secret_key(self.force_create_wallet)

--- a/src/utils/jcli.rs
+++ b/src/utils/jcli.rs
@@ -1,0 +1,114 @@
+use crate::utils::blockchain::Blockchain;
+use std::{
+    io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use thiserror::Error;
+
+/// jcli interactions that do not require a running jormungandr node
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("unable to create the address")]
+    AddressCreate(#[source] io::Error),
+    #[error("Invalid address")]
+    InvalidAddress(#[source] std::string::FromUtf8Error),
+    #[error("No secret key, did you mean to create a secret key too?")]
+    NoSecretKey,
+    #[error("Unable to extract the public key")]
+    ReadPublicKey(#[from] io::Error),
+    #[error("Cannot generate key {0}")]
+    GenerateKey(String),
+}
+
+pub struct Jcli<'a> {
+    blockchain: &'a Blockchain,
+    path: PathBuf,
+}
+
+impl<'a> Jcli<'a> {
+    pub fn new(blockchain: &'a Blockchain, path: PathBuf) -> Self {
+        Self { blockchain, path }
+    }
+
+    fn command(&self) -> Command {
+        Command::new(&self.path)
+    }
+
+    pub fn get_wallet_secret_key(&mut self, force: bool) -> Result<PathBuf, Error> {
+        let wallet_path = self.blockchain.get_wallet_secret();
+
+        if !wallet_path.is_file() || force {
+            self.gen_secret_key("Ed25519", &wallet_path)?;
+        }
+
+        Ok(wallet_path)
+    }
+
+    pub fn get_wallet_address(&mut self) -> Result<String, Error> {
+        let pk = self.get_public_key(self.blockchain.get_wallet_secret())?;
+
+        let address = self.make_address(pk.trim_end())?;
+
+        Ok(address.trim_end().to_owned())
+    }
+
+    fn make_address<PK: AsRef<str>>(&mut self, public_key: PK) -> Result<String, Error> {
+        let output = self
+            .command()
+            .args(&[
+                "address",
+                "account",
+                "--testing",
+                "--prefix=jorup_",
+                public_key.as_ref(),
+            ])
+            .output()
+            .map_err(Error::AddressCreate)?;
+        String::from_utf8(output.stdout).map_err(Error::InvalidAddress)
+    }
+
+    fn get_public_key<P>(&mut self, secret_key: P) -> Result<String, Error>
+    where
+        P: AsRef<Path>,
+    {
+        if !secret_key.as_ref().is_file() {
+            return Err(Error::NoSecretKey);
+        }
+
+        let output = self
+            .command()
+            .args(&[
+                "key",
+                "to-public",
+                "--input",
+                secret_key.as_ref().display().to_string().as_str(),
+            ])
+            .output()
+            .map_err(Error::ReadPublicKey)?;
+
+        String::from_utf8(output.stdout).map_err(Error::InvalidAddress)
+    }
+
+    fn gen_secret_key<P>(&mut self, key_type: &str, path: P) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+    {
+        let status = self
+            .command()
+            .args(&[
+                "key",
+                "generate",
+                "--type",
+                key_type,
+                path.as_ref().display().to_string().as_str(),
+            ])
+            .status()
+            .map_err(|_| Error::GenerateKey(key_type.to_owned()))?;
+        if status.success() {
+            Ok(())
+        } else {
+            return Err(Error::GenerateKey(key_type.to_owned()));
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod blockchain;
 pub mod download;
 pub mod github;
+pub mod jcli;
 pub mod release;
 pub mod runner;
 pub mod version;

--- a/src/utils/release.rs
+++ b/src/utils/release.rs
@@ -169,10 +169,6 @@ impl Release {
         }
     }
 
-    pub fn version(&self) -> &Version {
-        &self.version
-    }
-
     pub fn dir(&self) -> &PathBuf {
         &self.path
     }

--- a/src/utils/runner.rs
+++ b/src/utils/runner.rs
@@ -1,4 +1,4 @@
-use crate::utils::{blockchain::Blockchain, release::Release};
+use crate::utils::blockchain::Blockchain;
 use serde::{Deserialize, Serialize};
 use std::{
     io,
@@ -58,7 +58,7 @@ pub enum Error {
 }
 
 impl<'a> RunnerControl<'a> {
-    pub fn new(blockchain: &'a Blockchain, release: &Release) -> Result<Self, Error> {
+    pub fn new(blockchain: &'a Blockchain, bin_dir: PathBuf) -> Result<Self, Error> {
         let info_file = blockchain.get_runner_file();
 
         if info_file.is_file() {
@@ -86,8 +86,8 @@ impl<'a> RunnerControl<'a> {
         Ok(RunnerControl {
             blockchain,
             info: None,
-            jcli: release.get_jcli(),
-            jormungandr: release.get_jormungandr(),
+            jcli: bin_dir.join("jcli"),
+            jormungandr: bin_dir.join("jormungandr"),
         })
     }
 


### PR DESCRIPTION
When a user want to use custom binaries (not downloaded from GutHub) he/she should provide a directory containing them with `--bin` flag. This flag can be used with `jorup run` and `jorup wallet`. For using node management commands like `jorup shutdown` this flag is not required and `jcli` will be taken from the directory provided to `jorup run`.