### PR TITLE
github: search assets by platform+cpu instead of full name

### DIFF
--- a/src/utils/github.rs
+++ b/src/utils/github.rs
@@ -124,18 +124,12 @@ pub fn find_matching_release(
 
 impl Release {
     pub fn get_asset_url(&self, platform: &str) -> Option<&str> {
-        let ext = if platform.contains("windows") {
-            "zip"
-        } else {
-            "tar.gz"
-        };
-        let expected_name = format!(
-            "jormungandr-{}-{}-generic.{}",
-            self.version.to_version_number(),
-            platform,
-            ext
-        );
-        let maybe_asset = self.assets.iter().find(|asset| asset.name == expected_name);
+        let expected_name_part = format!("{}-generic", platform);
+        println!("{}", expected_name_part);
+        let maybe_asset = self
+            .assets
+            .iter()
+            .find(|asset| asset.name.contains(&expected_name_part));
         maybe_asset.map(|asset| &asset.url[..])
     }
 

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -45,16 +45,6 @@ impl Version {
         }
     }
 
-    pub fn to_version_number(&self) -> String {
-        match self {
-            Version::Nightly(None) => panic!("unconfigured nightly"),
-            Version::Nightly(Some((version, datetime))) => {
-                format!("{}-nightly.{}", version, datetime.format(DATEFMT))
-            }
-            Version::Stable(version) => format!("v{}", version),
-        }
-    }
-
     pub fn configure_nightly(self, last_stable_version: Self, datetime: DateTime<Utc>) -> Self {
         let mut version = match last_stable_version {
             Version::Stable(version) => version,


### PR DESCRIPTION
The full name search may cause problems when the asset name format is
changed in an unexpected way. Searching by a partial name is more
resistant to changes.

Closes #18.