### PR TITLE
migrate to lib

### DIFF
--- a/src/bin/jorup.rs
+++ b/src/bin/jorup.rs
@@ -1,10 +1,8 @@
-mod commands;
-mod common;
-mod config;
-mod jormungandr_config;
-mod utils;
+use jorup::{
+    commands::{self, Cmd},
+    utils,
+};
 
-use commands::Cmd;
 use std::{
     env::{self, consts::EXE_SUFFIX},
     ffi::OsStr,
@@ -24,7 +22,7 @@ fn main() {
 
 fn run(app: impl Cmd) {
     if let Err(error) = app.run() {
-        crate::utils::print_error(error);
+        utils::print_error(error);
 
         // TODO: https://github.com/rust-lang/rust/issues/43301
         //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod commands;
+pub mod common;
+pub mod config;
+pub mod jormungandr_config;
+pub mod utils;

--- a/src/utils/jorup_update.rs
+++ b/src/utils/jorup_update.rs
@@ -13,11 +13,14 @@ pub enum Error {
 }
 
 pub fn check_jorup_update() -> Result<Option<github::Release>, Error> {
+    check_update(github::JORUP)
+}
+
+pub fn check_update(app: &str) -> Result<Option<github::Release>, Error> {
     let current_version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
     let mut client = download::Client::new().map_err(Error::Client)?;
-    let available_release =
-        github::find_matching_release(&mut client, github::JORUP, VersionReq::Latest)
-            .map_err(Error::Release)?;
+    let available_release = github::find_matching_release(&mut client, app, VersionReq::Latest)
+        .map_err(Error::Release)?;
     let res = if &current_version < available_release.version() {
         Some(available_release)
     } else {


### PR DESCRIPTION
In order to use some good solutions, like update etc. in vit related cmds i need to expose some of jorup internals